### PR TITLE
Prevented player from spilling item from ghost cursor

### DIFF
--- a/scenarios/Von Neumann/hijack.lua
+++ b/scenarios/Von Neumann/hijack.lua
@@ -11,7 +11,7 @@ local table_event = {}
 local on_event_history = {}
 
 local function doAllEvents(event)
-	name = event.name
+	local name = event.name
 
 	for index,value in ipairs(table_event[name]) do
 		value(event)
@@ -19,7 +19,7 @@ local function doAllEvents(event)
 end
 
 script.on_event = function(event_ids, _function)
-	event_ids = (type(event_ids) == "table" and event_ids) or {event_ids}
+	local event_ids = (type(event_ids) == "table" and event_ids) or {event_ids}
 
 	for _, event_id in pairs(event_ids) do
 		if not table_event[event_id] then

--- a/scenarios/Von Neumann/railbot.lua
+++ b/scenarios/Von Neumann/railbot.lua
@@ -2,7 +2,7 @@
 
 
 
-railbot = {}
+local railbot = {}
 
 
 railbot.allowedGhostNames = {

--- a/scenarios/Von Neumann/vonNeumann.lua
+++ b/scenarios/Von Neumann/vonNeumann.lua
@@ -553,7 +553,7 @@ function vonn.on_player_crafted_item(event)
 	if banned[name] then
 		-- TODO: remove items on the next tick
 		player.remove_item({name=name, count=2000})
-		global.players[event.palyer_index].crafted = {name = name, count = item_stack.count}
+		global.players[player_index].crafted = {name = name, count = item_stack.count}
 	end
 end
 

--- a/scenarios/Von Neumann/vonNeumann.lua
+++ b/scenarios/Von Neumann/vonNeumann.lua
@@ -480,6 +480,15 @@ function vonn.newPlayer(event)
 		end
 	end
 
+	--store player in global storage
+	if not global.players then
+		global.players = {}
+	end
+
+	global.players[event.player_index] = {
+		crafted = {}
+	}
+
 	local numberPlayers = #game.players
 	local msg = "newPlayer complete: " .. numberPlayers
 	vonn.kprint(msg)
@@ -544,6 +553,7 @@ function vonn.on_player_crafted_item(event)
 	if banned[name] then
 		-- TODO: remove items on the next tick
 		player.remove_item({name=name, count=2000})
+		global.players[event.palyer_index].crafted = {name = name, count = item_stack.count}
 	end
 end
 
@@ -779,9 +789,13 @@ function vonn.spillPlayerItems(player,surface,uninsertableItems)
 	local surface = game.surfaces[surface]
 	local sum = 0
 
+	local globalCraftedItem = global.players[player.index].crafted
+
 	for item,count in pairs(uninsertableItems) do
-		surface.spill_item_stack(position,{name=item, count=count},false,player.force,false)
-		sum = count + sum
+		if not item.name == globalCraftedItem.name then
+			surface.spill_item_stack(position,{name=item, count=count},false,player.force,false)
+			sum = count + sum
+		end
 	end
 
 	return sum
@@ -821,6 +835,8 @@ function vonn.on_player_inventory_changed(event)
 			-- assume player cheat_mode crafted an item, so ghost it
 			for item,count in pairs(itemsRemoved) do
 				player.cursor_ghost = item
+				player.remove_item(item)
+				global.players[event.player_index].crafted = {}
 			end
 		end
 


### PR DESCRIPTION
I came across: https://mods.factorio.com/mod/vonNeumann/discussion/5e5447b0cc9c64000e000591

This is not duo to a conflict with another mod  but by a change in how cheat mode is handled in (i think) 0.17. What seems to happen is that whenever you grab a crafting item from the list in cheat mode you get a stack of 1 into your cursor. It is impossible to clear this without either spilling this item or returning it to your inventory (your code spills it to the floor).

This MR keeps track of the latest item crafted by the user (in this case by cheat mode) and keeps it in memory to prevent it from being dropped.